### PR TITLE
Use user_config_dir

### DIFF
--- a/art/_paths.py
+++ b/art/_paths.py
@@ -8,7 +8,7 @@ import appdirs
 _appdirs = appdirs.AppDirs('art')
 artifacts_file = 'artifacts.yml'
 artifacts_lock_file = 'artifacts.lock.yml'
-config_file = os.path.join(_appdirs.user_data_dir, 'config.yml')
+config_file = os.path.join(_appdirs.user_config_dir, 'config.yml')
 cache_dir = _appdirs.user_cache_dir
 
 


### PR DESCRIPTION
This changes the location where art stores its user config from `~/.local/share/art/` to `~/.config/art/`.

:warning: This means you will need to run `art configure` again.

Closes #3