### PR TITLE
Preserve filesystem permissions of artifacts (take 2)

### DIFF
--- a/art/command_line.py
+++ b/art/command_line.py
@@ -148,3 +148,8 @@ def install():
                     with archive.open(member) as fmember:
                         with open(target, 'wb') as ftarget:
                             shutil.copyfileobj(fmember, ftarget)
+
+                    # if create_system is Unix (3), external_attr contains filesystem permissions
+                    if member.create_system == 3:
+                        perms = member.external_attr >> 16
+                        os.chmod(target, perms)

--- a/art/command_line.py
+++ b/art/command_line.py
@@ -135,14 +135,14 @@ def install():
         archive = zipfile.ZipFile(archive_file)
 
         # iterate over the zip archive
-        for member in archive.namelist():
-            if member.endswith('/'):
+        for member in archive.infolist():
+            if member.is_dir():
                 # skip directories, they will be created as-is
                 continue
             for match, translate in installs:
-                if match(member):
-                    target = translate(member)
-                    click.echo('* install: %s => %s' % (member, target))
+                if match(member.filename):
+                    target = translate(member.filename)
+                    click.echo('* install: %s => %s' % (member.filename, target))
                     if os.sep in target:
                         _paths.mkdirs(os.path.dirname(target))
                     with archive.open(member) as fmember:


### PR DESCRIPTION
This builds on #9 and makes the following changes:
- Change extraction loop to use `ZipInfo` object rather than repeated name lookups
- Refactor out `install_member` -- the body of that `for` loop was getting too big
- Keep only the "normal" permissions bits (`0777`)
  - Ignore any "special" permissions bits like setuid, setgid, sticky
  - It's allowable, but don't pass the file "type" bits (`S_IFMT`) to `chmod`

Closes #8 