### PR TITLE
Add long description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     description='Gitlab artifact manager',
     long_description = read_project_file('README.md'),
     long_description_content_type = 'text/markdown',
-    url='https://github.com/kosma/art',
+    url='https://github.com/kosma/gitlab-art',
     author='Kosma Moczek',
     author_email='kosma@kosma.pl',
     license='WTFPL',

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,18 @@
+import os
 from setuptools import setup, find_packages
+
+def read_project_file(path):
+    proj_dir = os.path.dirname(__file__)
+    path = os.path.join(proj_dir, path)
+    with open(path, 'r') as f:
+        return f.read()
 
 setup(
     name='gitlab-art',
     version='0.2.0',
     description='Gitlab artifact manager',
+    long_description = read_project_file('README.md'),
+    long_description_content_type = 'text/markdown',
     url='https://github.com/kosma/art',
     author='Kosma Moczek',
     author_email='kosma@kosma.pl',


### PR DESCRIPTION
This long description shows up on the PyPI project page (see e.g. [scuba](https://pypi.org/project/scuba/)).