### PR TITLE
Fix issues with new job-by-ref behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
         build/apidoc/html/: docs/api/
         VERSION: docs/VERSION
     - project: kosma/foobar-firmware
-      ref: tags/1.4.0
+      ref: 1.4.0
       job: firmware-8051
       install:
         build/8051/release/firmware.bin: blobs/firmware-8051.blob

--- a/art/command_line.py
+++ b/art/command_line.py
@@ -31,8 +31,8 @@ def get_ref_last_successful_job(project, ref, job_name):
                 # Turn ProjectPipelineJob into ProjectJob
                 return project.jobs.get(job.id, lazy=True)
 
-    raise Exception("Could not find latest successful '{}' job for commit {}".format(
-        job_name, commit))
+    raise Exception("Could not find latest successful '{}' job for {} ref {}".format(
+        job_name, project.path_with_namespace, ref))
 
 
 def zip_name(project, job_id):
@@ -95,7 +95,7 @@ def configure(**kwargs):
 
 @main.command()
 def update():
-    """Update latest tag/branch commits."""
+    """Update latest tag/branch job IDs."""
 
     gitlab = get_gitlab()
     artifacts = _yaml.load(_paths.artifacts_file)


### PR DESCRIPTION
This fixes the issues noted in #15:
- https://github.com/kosma/gitlab-art/pull/15#discussion_r431926015
- https://github.com/kosma/gitlab-art/pull/15#issuecomment-635427182

Testing bad ref (`ref: tags/v1.2.3`):
```
Traceback (most recent call last):
 ...
Exception: Could not find latest successful 'build' job for jreinhart/testproject ref tags/v1.2.3
```

Testing good ref (`ref: v1.2.3`):
```
(no errors)
```
