### PR TITLE
Restore compatibility with Python 3.5

### DIFF
--- a/art/command_line.py
+++ b/art/command_line.py
@@ -171,7 +171,7 @@ def install():
 
         # iterate over the zip archive
         for member in archive.infolist():
-            if member.is_dir():
+            if member.filename.endswith('/'):
                 # skip directories, they will be created as-is
                 continue
             for match, translate in installs:


### PR DESCRIPTION
- `ZipInfo.is_dir()` was added in Python 3.6.

Closes #18 -- although `gitlab-art` should probably have Python version compatibility defined in `setup.py` (see [scuba](https://github.com/JonathonReinhart/scuba/blob/516a513c63d466ee8dddffb85c397b1e42dec35c/setup.py#L51)) and CI tests (see [scuba](https://github.com/JonathonReinhart/scuba/blob/516a513c63d466ee8dddffb85c397b1e42dec35c/.github/workflows/build-test.yml#L14)).