### PR TITLE
Add support for CI_JOB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 1. Create a Gitlab private token and save it in `art` configuration:
 
     ```shell
-    art configure https://gitlab.example.com/ 'as1!df2@gh3#jk4$'
+    art configure https://gitlab.example.com/ --token-type private 'as1!df2@gh3#jk4$'
     ```
 
 2. Create `artifacts.yml` with definitions of needed artifacts:
@@ -56,7 +56,7 @@ Add the following commands to your `.gitlab-ci.yml`:
 ```yaml
 before_script:
   - sudo pip install https://github.com/kosma/art
-  - art configure <url> <token>
+  - art configure <url> --token-type <private|job> <token>
   - art download
   - art install
 cache:
@@ -72,9 +72,6 @@ automatically set to `.art-cache` so it can be preserved across jobs.
 
 ## Bugs and limitations
 
-* Gitlab's `$CI_BUILD_TOKEN` infrastructure doesn't support accessing artifacts,
-  so a private token must be used. This is very unfortunate and kludgey.
-  This might be fixed in future Gitlab releases (if I bug them hard enough).
 * Multiple Gitlab instances are not supported (and would be non-trivial to support).
 * Error handling is very rudimentary: any non-trivial exceptions simply propagate
   until Python dumps a stack trace.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Add the following commands to your `.gitlab-ci.yml`:
 ```yaml
 before_script:
   - sudo pip install https://github.com/kosma/art
-  - art configure <url> --token-type <private|job> <token>
+  - art configure <url> --token-type {private,job} <token>
   - art download
   - art install
 cache:

--- a/art/_config.py
+++ b/art/_config.py
@@ -10,16 +10,20 @@ from . import _yaml
 def save(gitlab_url, token_type, token):
     config = {
         'gitlab_url': gitlab_url,
+        'token_type': token_type,
+        'token': token,
     }
-    if token_type == 'private':
-        config['private_token'] = token
-        config['job_token'] = None
-    elif token_type == 'job':
-        config['job_token'] = token
-        config['private_token'] = None
     _paths.mkdirs(os.path.dirname(_paths.config_file))
     _yaml.save(_paths.config_file, config)
 
 
 def load():
-    return _yaml.load(_paths.config_file)
+    config = _yaml.load(_paths.config_file)
+   
+    # migrate legacy private_token to token/token_type
+    if 'private_token' in config:
+        config['token'] = config['private_token']
+        config['token_type'] = 'private'
+        del config['private_token']
+        
+    return config

--- a/art/_config.py
+++ b/art/_config.py
@@ -3,9 +3,18 @@
 from __future__ import absolute_import
 
 import os
+
+import click
+
 from . import _paths
 from . import _yaml
 
+
+class ConfigException(click.ClickException):
+    """An exception caused by invalid configuration settings."""
+    def __init__(self, config_key, message):
+        msg = 'config.{}: {}'.format(config_key, message)
+        super().__init__(msg)
 
 def save(gitlab_url, token_type, token):
     config = {

--- a/art/_config.py
+++ b/art/_config.py
@@ -25,14 +25,43 @@ def save(gitlab_url, token_type, token):
     _paths.mkdirs(os.path.dirname(_paths.config_file))
     _yaml.save(_paths.config_file, config)
 
-
 def load():
     config = _yaml.load(_paths.config_file)
-   
-    # migrate legacy private_token to token/token_type
-    if 'private_token' in config:
-        config['token'] = config['private_token']
-        config['token_type'] = 'private'
-        del config['private_token']
-        
+
+    if not config:
+        raise click.ClickException('No configuration found. Run "art configure" first.')
+
+    # convert old config to current representation
+    migrate(config)
+
+    validate(config)
+
     return config
+
+def migrate(config):
+    """Perform conversions to maintain backwards-compatibility"""
+
+    # migrate legacy private_token value if it can be
+    # done without overwriting an existing value
+    if 'private_token' in config and 'token' not in config:
+        config['token'] = config['private_token']
+        del config['private_token']
+
+    # default to private tokens if not specified
+    if 'token_type' not in config:
+        config['token_type'] = 'private'
+
+def validate(config):
+    """Ensure the configuration meets expectations"""
+
+    required_fields = ('token', 'token_type', 'gitlab_url')
+    for field in required_fields:
+        if field not in config:
+            raise ConfigException(field, 'Required config element is missing. Run "art configure".')
+
+    # warn the user if they have both private_token and token configured
+    # the private_token element is a legacy field and should be removed
+    if 'private_token' in config and 'token' in config:
+        click.secho('Warning: ', nl=False, fg='yellow')
+        click.echo('Config includes both "token" and "private_token" elements. ', nl=False)
+        click.echo('Only the "token" value will be used.')

--- a/art/_config.py
+++ b/art/_config.py
@@ -2,17 +2,21 @@
 
 from __future__ import absolute_import
 
-import re
 import os
 from . import _paths
 from . import _yaml
 
 
-def save(gitlab_url, private_token):
+def save(gitlab_url, token_type, token):
     config = {
         'gitlab_url': gitlab_url,
-        'private_token': private_token,
     }
+    if token_type == 'private':
+        config['private_token'] = token
+        config['job_token'] = None
+    elif token_type == 'job':
+        config['job_token'] = token
+        config['private_token'] = None
     _paths.mkdirs(os.path.dirname(_paths.config_file))
     _yaml.save(_paths.config_file, config)
 

--- a/art/_paths.py
+++ b/art/_paths.py
@@ -1,6 +1,5 @@
 import errno
 import os
-import sys
 
 import appdirs
 

--- a/art/command_line.py
+++ b/art/command_line.py
@@ -19,7 +19,7 @@ S_IRWXUGO = 0o0777
 
 def get_gitlab():
     config = _config.load()
-    return Gitlab(config['gitlab_url'], private_token=config['private_token'])
+    return Gitlab(config['gitlab_url'], private_token=config['private_token'], job_token=config['job_token'])
 
 
 def get_ref_last_successful_job(project, ref, job_name):
@@ -86,7 +86,8 @@ def main(cache):
 
 @main.command()
 @click.argument('gitlab_url')
-@click.argument('private_token')
+@click.option('--token-type', type=click.Choice(['private', 'job']), default='private')
+@click.argument('token')
 def configure(**kwargs):
     """Configure Gitlab URL and access token."""
 

--- a/art/command_line.py
+++ b/art/command_line.py
@@ -30,7 +30,7 @@ def is_using_job_token(gitlab):
     """Determine if the GitLab client will use a job token to authenticate.
 
     Job tokens cannot access the full GitLab API. The GitLab client uses a job
-    token as a last resort when other tokens are available.
+    token as a last resort when other tokens are unavailable.
     """
     # private and oauth tokens will be used, if available
     if gitlab.private_token is not None or gitlab.oauth_token is not None:

--- a/art/command_line.py
+++ b/art/command_line.py
@@ -24,7 +24,7 @@ def get_gitlab():
     if config['token_type'] == 'job':
         return Gitlab(config['gitlab_url'], job_token=config['token'])
 
-    raise Exception("Unknown token type: {}".format(config['token_type']))
+    raise _config.ConfigException('token_type', 'Unknown token type: {}'.format(config['token_type']))
 
 def is_using_job_token(gitlab):
     """Determine if the GitLab client will use a job token to authenticate.
@@ -47,7 +47,7 @@ def get_ref_last_successful_job(project, ref, job_name):
                 # Turn ProjectPipelineJob into ProjectJob
                 return project.jobs.get(job.id, lazy=True)
 
-    raise Exception("Could not find latest successful '{}' job for {} ref {}".format(
+    raise click.ClickException("Could not find latest successful '{}' job for {} ref {}".format(
         job_name, project.path_with_namespace, ref))
 
 
@@ -118,7 +118,7 @@ def update():
 
     # As of GitLab 16.4, you cannot access the projects and jobs APIs with a job token
     if is_using_job_token(gitlab):
-        raise Exception('A job token cannot be used to update artifacts')
+        raise _config.ConfigException('token_type', 'A job token cannot be used to update artifacts')
 
     artifacts = _yaml.load(_paths.artifacts_file)
     for entry in artifacts:

--- a/art/command_line.py
+++ b/art/command_line.py
@@ -128,7 +128,7 @@ def download():
             _cache.get(filename)
         except KeyError:
             click.echo('* %s: %s => downloading...' % (entry['project'], entry['job_id']))
-            proj = gitlab.projects.get(entry['project'])
+            proj = gitlab.projects.get(entry['project'], lazy=True)
             job = proj.jobs.get(entry['job_id'], lazy=True)
             with _cache.save_file(filename) as f:
                 job.artifacts(streamed=True, action=f.write)

--- a/art/command_line.py
+++ b/art/command_line.py
@@ -19,7 +19,12 @@ S_IRWXUGO = 0o0777
 
 def get_gitlab():
     config = _config.load()
-    return Gitlab(config['gitlab_url'], private_token=config['private_token'], job_token=config['job_token'])
+    if config['token_type'] == 'private':
+        return Gitlab(config['gitlab_url'], private_token=config['token'])
+    if config['token_type'] == 'job':
+        return Gitlab(config['gitlab_url'], job_token=config['token'])
+
+    raise Exception("Unknown token type: {}".format(config['token_type']))
 
 
 def get_ref_last_successful_job(project, ref, job_name):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'PyYAML',
         'appdirs',
         'click',
-        'python-gitlab',
+        'python-gitlab>=1.12.0',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Closes #26 -- Adds support for:
```shell
$ art configure $GITLAB_URL --token-type [private|job] $TOKEN
```
and maintains legacy support for:
```shell
$ art configure $GITLAB_URL $TOKEN
```