### PR TITLE
Download artifacts during install if necessary

### DIFF
--- a/art/_cache.py
+++ b/art/_cache.py
@@ -26,12 +26,16 @@ def save(filename, content):
         f.write(content)
 
 
+def contains(filename):
+    return os.path.isfile(cache_path(filename))
+
+
 def get(filename):
     try:
         return open(cache_path(filename), 'rb')
     except IOError as exc:
         # translate "No such file or directory" into KeyError
         if exc.errno == errno.ENOENT:
-            raise KeyError(filename)
+            raise KeyError(filename) from exc
         else:
             raise


### PR DESCRIPTION
The install command only works if the required artifacts have been
downloaded. Rather than print an error message when an archive file is
missing, just try to download it.

Closes #28 