### PR TITLE
Add python_requires >= 3.5 to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ def read_project_file(path):
 setup(
     name='gitlab-art',
     version=version,
+    python_requires='>=3.5',
     description='Gitlab artifact manager',
     long_description = read_project_file('README.md'),
     long_description_content_type = 'text/markdown',


### PR DESCRIPTION
This prevents installation on older versions of python when using pip >= 9.0.0. The minimum version of each dependency still support 3.5.

    appdirs==1.4.4
    click==7.1.2
    python-gitlab==1.15.0
    PyYAML==5.3.1