### PR TITLE
Expect OSErrors when saving or loading yaml

### DIFF
--- a/art/_yaml.py
+++ b/art/_yaml.py
@@ -1,13 +1,21 @@
 # -*- coding: utf-8 -*-
 
+import click
 import yaml
 
 
 def load(path):
-    with open(path, 'r') as stream:
-        return yaml.safe_load(stream=stream)
-
+    try:
+        with open(path, 'r') as stream:
+            return yaml.safe_load(stream=stream)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise click.ClickException('Failed to read file: %s' % exc)
 
 def save(path, obj):
-    with open(path, 'w') as stream:
-        yaml.safe_dump(obj, stream=stream, default_flow_style=False)
+    try:
+        with open(path, 'w') as stream:
+            yaml.safe_dump(obj, stream=stream, default_flow_style=False)
+    except OSError as exc:
+        raise click.ClickException('Failed to write file: %s' % exc)

--- a/art/command_line.py
+++ b/art/command_line.py
@@ -155,6 +155,9 @@ def update():
         raise _config.ConfigException('token_type', 'A job token cannot be used to update artifacts')
 
     artifacts = _yaml.load(_paths.artifacts_file)
+    if not artifacts:
+        raise click.ClickException('The %s file was not found or did not contain any entries' % _paths.artifacts_file)
+
     for entry in artifacts:
         fail_msg = 'Failed to get last successful "%s" job for "%s" ref "%s"' % (
             entry['job'],
@@ -176,6 +179,8 @@ def download():
 
     gitlab = get_gitlab()
     artifacts_lock = _yaml.load(_paths.artifacts_lock_file)
+    if not artifacts_lock:
+        raise click.ClickException('No entries in %s file. Run "art update" first.' % _paths.artifacts_lock_file)
 
     for entry in artifacts_lock:
         filename = zip_name(entry)
@@ -192,6 +197,8 @@ def install(keep_empty_dirs):
 
     gitlab = get_gitlab()
     artifacts_lock = _yaml.load(_paths.artifacts_lock_file)
+    if not artifacts_lock:
+        raise click.ClickException('No entries in %s file. Run "art update" first.' % _paths.artifacts_lock_file)
 
     for entry in artifacts_lock:
         # dictionary of src:dest pairs representing artifacts to install


### PR DESCRIPTION
Report better errors to the user when configuration files are not found or fail to read.