### PR TITLE
Replace appdirs with platformdirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ art install --json
 
 ## File locations
 
-`art` uses [appdirs](https://github.com/ActiveState/appdirs) to store configuration
+`art` uses [platformdirs](https://github.com/tox-dev/platformdirs) to store configuration
 and cache files. When running under CI environment, the default cache directory is
 automatically set to `.art-cache` so it can be preserved across jobs.
 

--- a/art/_paths.py
+++ b/art/_paths.py
@@ -1,14 +1,14 @@
 import errno
 import os
 
-import appdirs
+import platformdirs
 
 
-_appdirs = appdirs.AppDirs('art')
+_platformdirs = platformdirs.PlatformDirs('art')
 artifacts_file = 'artifacts.yml'
 artifacts_lock_file = 'artifacts.lock.yml'
-config_file = os.path.join(_appdirs.user_config_dir, 'config.yml')
-cache_dir = _appdirs.user_cache_dir
+config_file = os.path.join(_platformdirs.user_config_dir, 'config.yml')
+cache_dir = _platformdirs.user_cache_dir
 
 
 def strip_components(path, num):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'PyYAML',
-        'appdirs',
+        'platformdirs',
         'click',
         'python-gitlab>=1.12.0',
     ],


### PR DESCRIPTION
The appdirs project has been deprecated and platformdirs is a more up-to-date fork.